### PR TITLE
don't do Pkg.add or Pkg.checkout on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.add("RequestsCache"); Pkg.checkout("RequestsCache")'
+    - julia -e 'Pkg.clone(pwd())'
     - julia -e 'Pkg.test("RequestsCache",coverage=true)'
 after_success:
     - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("RequestsCache")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'; fi


### PR DESCRIPTION
the `Pkg.clone(pwd())` already accomplishes this, and properly builds non-master branches or PR's
