### PR TITLE
Add ability to clear, overwrite cache; some bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,9 @@ Pkg.add("RequestsCache")
 ## Usage
 
 ```julia
-import RequestsCache: Session, CachedSession
-import RequestsCache: get
+import RequestsCache: CachedSession, get
 
-session = Session()
-#session = CachedSession()
 session = CachedSession(cache_name="cache.jld", backend="jld", expire_after=Base.Dates.Day(1))
-#println(session)
 
 response = get(session, "http://httpbin.org/get", query = Dict("title" => "page1"))
 

--- a/src/RequestsCache.jl
+++ b/src/RequestsCache.jl
@@ -12,11 +12,10 @@ Inspired by [requests-cache](http://requests-cache.readthedocs.org/).
 
 module RequestsCache
 
-    export get, CachedSession, Session
+    export get, CachedSession
 
-    #import Dates
     import Base: read
-    import Requests: do_request, do_stream_request, ResponseStream
+    import Requests: get, do_request, do_stream_request, ResponseStream
     import URIParser: URI
     import HttpCommon: Response
     import JLD: jldopen, write
@@ -45,10 +44,6 @@ module RequestsCache
         else
             error("'$(backend)' is not a supported backend")
         end
-    end
-
-    function Session()
-        CachedSessionType("", "", Base.Dates.Day(0))
     end
 
     immutable CachedResponse

--- a/src/RequestsCache.jl
+++ b/src/RequestsCache.jl
@@ -15,7 +15,7 @@ module RequestsCache
     export get, CachedSession
 
     import Base: read
-    import Requests: get, do_request, do_stream_request, ResponseStream
+    import Requests: do_request, do_stream_request, ResponseStream
     import URIParser: URI
     import HttpCommon: Response
     import JLD: jldopen, write

--- a/src/RequestsCache.jl
+++ b/src/RequestsCache.jl
@@ -149,6 +149,10 @@ module RequestsCache
         end
     end
 
+    function clear(session::CachedSessionType)
+        rm(session.cache_name)
+    end
+
     for f in [:get, :post, :put, :delete, :head,
               :trace, :options, :patch, :connect]
         f_str = uppercase(string(f))

--- a/src/RequestsCache.jl
+++ b/src/RequestsCache.jl
@@ -120,7 +120,6 @@ module RequestsCache
 
     function execute_remote(prepared_query::PreparedQuery)
         println("execute_remote $(prepared_query.verb) $(prepared_query.uri) $(prepared_query.args)")
-        #prepared_query.verb(string(prepared_query.uri); prepared_query.args...)
         verb = uppercase(string(prepared_query.verb))
         if !contains(verb, "_STREAMING")
             do_request(prepared_query.uri, verb; prepared_query.args...)
@@ -167,7 +166,6 @@ module RequestsCache
     for f in [:get, :post, :put, :delete, :head,
               :trace, :options, :patch, :connect]
         f_str = uppercase(string(f))
-        #f_stream = symbol(string(f, "_streaming"))
         @eval begin
             function ($f)(session::CachedSessionType, uri::URI, data::String; headers::Dict=Dict(), overwrite = false)
                 #do_request(uri, $f_str; data=data, headers=headers)
@@ -181,12 +179,6 @@ module RequestsCache
                 prepared_query = create_query($f_str, uri;  args...)
                 response = execute(prepared_query; session=session, overwrite = overwrite)
             end
-
-            #function ($f_stream)(uri::URI, data::String; headers::Dict=Dict())
-            #    do_stream_request(uri, $f_str; data=data, headers=headers)
-            #end
-            #($f_stream)(uri::String; args...) = ($f_stream)(URI(uri); args...)
-            #($f_stream)(uri::URI; args...) = do_stream_request(uri, $f_str; args...)
         end
     end
 


### PR DESCRIPTION
Kind of a lot going on for one PR, but here's the gist:

- Add `clear(session::CachedSession)` to clear the cache -- it just deletes the file.
- Add `overwrite` keyword to force overwrite the cached result.
- Various bug fixes

I'm happy to discuss any of these changes.